### PR TITLE
Update SSL host path

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -15,7 +15,7 @@ spec:
       volumes:
         - name: ssl-certs
           hostPath:
-            path: /usr/share/ca-certificates
+            path: /etc/ssl/certs
       containers:
       - image: quay.io/uswitch/sqs-autoscaler-controller:master
         imagePullPolicy: Always


### PR DESCRIPTION
On kubernetes 1.8+ the certificates can be found at /etc/ssl/certs rather then the old path mentioned here.